### PR TITLE
Docs: Fix typo `migrations_path` => `migrations_paths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ development:
 + telemetry:
 +   <<: *default
 +   database: telemetry_development
-+   migrations_path: db/telemetry_migrate
++   migrations_paths: db/telemetry_migrate
 ```
 
 Once you've done that, you can execute:


### PR DESCRIPTION
As per RoR docs, the correct key is `migrations_paths`:
https://guides.rubyonrails.org/active_record_multiple_databases.html

It seems like it's a common confusion since there used to be `migrations_path` class method in the past (???):
https://apidock.com/rails/v3.0.9/ActiveRecord/Schema/migrations_path/class

https://github.com/rails/rails/issues/39090

Looking at the source code, I'm not even sure what `migrations_path` refers to here:
https://api.rubyonrails.org/classes/ActiveRecord/MigrationContext.html#method-i-migrate

Seems like the docs are no longer in line with the code. Or it's used somewhere below in `down`/`up` methods.

EDIT: I didn't test this change. I couldn't run `rails db:schema:load:telemetry` without errors.