### PR TITLE
columns improvements

### DIFF
--- a/app/models/solid_telemetry/span.rb
+++ b/app/models/solid_telemetry/span.rb
@@ -14,10 +14,10 @@ module SolidTelemetry
     scope :active_job, -> { where instrumentation_scope_name: "OpenTelemetry::Instrumentation::ActiveJob" }
     scope :rack, -> { where instrumentation_scope_name: "OpenTelemetry::Instrumentation::Rack" }
 
-    scope :successful, -> { where "http_status_code LIKE ?", "2%" }
-    scope :redirection, -> { where "http_status_code LIKE ?", "3%" }
-    scope :client_error, -> { where "http_status_code LIKE ?", "4%" }
-    scope :server_error, -> { where "http_status_code LIKE ?", "5%" }
+    scope :successful, -> { where http_status_code: 200..299 }
+    scope :redirection, -> { where http_status_code: 300..399 }
+    scope :client_error, -> { where http_status_code: 400..499 }
+    scope :server_error, -> { where http_status_code: 500..599 }
 
     delegate :name, to: :span_name
 

--- a/lib/generators/solid_telemetry/install/install_generator.rb
+++ b/lib/generators/solid_telemetry/install/install_generator.rb
@@ -32,10 +32,12 @@ class SolidTelemetry::InstallGenerator < Rails::Generators::Base
   end
 
   def virtual_http_status_code
-    if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) || defined?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
+    if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
+      "(span_attributes->>'http.status_code')::INTEGER"
+    elsif defined?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
       "span_attributes->>'http.status_code'"
     elsif defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
-      "span_attributes->'$.\\\"http.status_code\\\"'"
+      "JSON_VALUE(span_attributes, '$.\\\"http.status_code\\\"' RETURNING DECIMAL)"
     end
   end
 
@@ -43,7 +45,7 @@ class SolidTelemetry::InstallGenerator < Rails::Generators::Base
     if defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) || defined?(ActiveRecord::ConnectionAdapters::SQLite3Adapter)
       "instrumentation_scope->>'name'"
     elsif defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
-      "instrumentation_scope->'$.\\\"name\\\"'"
+      "JSON_VALUE(instrumentation_scope, '$.\\\"name\\\"')"
     end
   end
 

--- a/lib/generators/solid_telemetry/install/templates/db/telemetry_schema.rb.tt
+++ b/lib/generators/solid_telemetry/install/templates/db/telemetry_schema.rb.tt
@@ -93,7 +93,7 @@ ActiveRecord::Schema[<%= schema_version %>].define(version: 1) do
     t.json "tracestate"
     t.decimal "duration"
     t.virtual "hostname", type: :string, as: "<%= virtual_hostname %>", stored: true
-    t.virtual "http_status_code", type: :string, as: "<%= virtual_http_status_code %>", stored: true
+    t.virtual "http_status_code", type: :integer, as: "<%= virtual_http_status_code %>", stored: true
     t.virtual "instrumentation_scope_name", type: :string, as: "<%= virtual_instrumentation_scope_name %>", stored: true
     t.index ["hostname"], name: "index_solid_telemetry_spans_on_hostname"
     t.index ["http_status_code"], name: "index_solid_telemetry_spans_on_http_status_code"


### PR DESCRIPTION
in mysql, the instrumentation scope name was stored as `"OpenTelemetry::...::ActiveRecord"` (eg. extra quotes)

Also, make the http status code an integer, which makes more sense.